### PR TITLE
Sync Users & User Groups From Slack Into DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ After finishing steps 3 and 4, you can run locally with `rails s`. The API can b
 ## 2. Adding To Heroku
 Deploy your app to Heroku or another site. You can use Heroku's CLI, or deploy from your forked repo. Add the following add-ons:
 1. Postgres (required)
+2. Heroku Scheduler (recommended for running tasks, but you can use something else)
+  - Create a task to run `rake sync_users:get_users && rake sync_users:get_user_groups` once a week
 2. Papertrail (recommended)
 
 ## 3. Adding To Slack
@@ -31,13 +33,15 @@ Create a new App to your workspace for Praise Bot.
 ## 4. The Bot
 1. Add a bot user under `Features & Functionality`. Then go to `OAuth & Permissions` to find your bot's auth key.
 
-2. Run `bundle exec figaro install` to generate a `config/application.yml` file. Add the following ENV (environment) variables to this file locally.
+2. Under this section, be sure the bot has permission to: `usergroups:read`, `users.profile:read`, `users:read`, `chat:write`, and `chat:write.customize`.
 
-3. Replace this value with your bot's key: `slack_bot_auth: xoxb-xxxxxxx-xxxxxx-xxxxxx`
+3. Run `bundle exec figaro install` to generate a `config/application.yml` file. Add the following ENV (environment) variables to this file locally.
 
-4. In `Basic Information` > `App Credentials` you will find your app's client ID and secret. Add the signing secret as an ENV variable. `slack_secret_signature: xxxxxxxxxxxxxxxx`
+4. Replace this value with your bot's key: `slack_bot_auth: xoxb-xxxxxxx-xxxxxx-xxxxxx`
 
-5. Also add a ENV variable with the channel ID to post to. `slack_praise_channel: xxxxx`
+5. In `Basic Information` > `App Credentials` you will find your app's client ID and secret. Add the signing secret as an ENV variable. `slack_secret_signature: xxxxxxxxxxxxxxxx`
+
+6. Also add a ENV variable with the channel ID to post to. `slack_praise_channel: xxxxx`
 
 **How do I get the channel ID?** If you go to the team's Slack in your browser, and then click into the channel you want to post to, the channel ID will be the last string after the last `/` in the URL.
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ After finishing steps 3 and 4, you can run locally with `rails s`. The API can b
 Deploy your app to Heroku or another site. You can use Heroku's CLI, or deploy from your forked repo. Add the following add-ons:
 1. Postgres (required)
 2. Heroku Scheduler (recommended for running tasks, but you can use something else)
-  - Create a task to run `rake sync_users:get_users && rake sync_users:get_user_groups` once a week
-2. Papertrail (recommended)
+  - Create a task to run `rake sync_users:get_users && rake sync_users:get_user_groups` once a week.
+3. Papertrail (recommended)
 
 ## 3. Adding To Slack
 Create a new App to your workspace for Praise Bot.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Praise
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/db/migrate/20200330170525_create_user_list.rb
+++ b/db/migrate/20200330170525_create_user_list.rb
@@ -1,0 +1,11 @@
+class CreateUserList < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :slack_id
+      t.string :display_name
+      t.string :actual_name
+      t.boolean :is_group
+    end
+    add_index :users, :slack_id, unique: true
+  end
+end

--- a/db/migrate/20200330170525_create_user_list.rb
+++ b/db/migrate/20200330170525_create_user_list.rb
@@ -5,6 +5,7 @@ class CreateUserList < ActiveRecord::Migration[5.2]
       t.string :display_name
       t.string :actual_name
       t.boolean :is_group
+      t.boolean :is_deleted, :default => false
     end
     add_index :users, :slack_id, unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_03_30_170525) do
     t.string "display_name"
     t.string "actual_name"
     t.boolean "is_group"
+    t.boolean "is_deleted", default: false
     t.index ["slack_id"], name: "index_users_on_slack_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_11_204619) do
+ActiveRecord::Schema.define(version: 2020_03_30_170525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "slack_id"
+    t.string "display_name"
+    t.string "actual_name"
+    t.boolean "is_group"
+    t.index ["slack_id"], name: "index_users_on_slack_id", unique: true
+  end
 
   create_table "views", force: :cascade do |t|
     t.string "view_id"

--- a/lib/slack_connect.rb
+++ b/lib/slack_connect.rb
@@ -1,0 +1,22 @@
+class SlackConnect
+  require 'json'
+
+  def self.get(slack_method, limit, page)
+    token = ENV["slack_bot_auth"]
+    begin
+      Rails.logger.info("Retrieving from #{url}")
+      url = 'https://slack.com/api/methods/' + slack_method + '?token=' + token
+      if limit
+        url += '&limit=' + limit
+      end
+      if page
+        url+= '&cursor=' + page
+      end
+      response = HTTParty.get(url, options)
+      return response.body
+    rescue => e
+      puts e
+      return null
+    end
+  end
+end

--- a/lib/slack_connect.rb
+++ b/lib/slack_connect.rb
@@ -4,13 +4,13 @@ class SlackConnect
   def self.get(slack_method, limit, page)
     token = ENV["slack_bot_auth"]
     begin
-      Rails.logger.info("Retrieving from #{url}")
-      url = 'https://slack.com/api/methods/' + slack_method + '?token=' + token
-      if limit
-        url += '&limit=' + limit
+      Rails.logger.info("Retrieving from #{slack_method}")
+      url = "https://slack.com/api/methods/#{slack_method}?token=#{token}"
+      if limit.present?
+        url += "&limit=#{limit}"
       end
-      if page
-        url+= '&cursor=' + page
+      if page.present?
+        url+= "&cursor=#{page}"
       end
       response = HTTParty.get(url, options)
       return response.body

--- a/lib/slack_connect.rb
+++ b/lib/slack_connect.rb
@@ -12,7 +12,7 @@ class SlackConnect
       if page.present?
         url+= "&cursor=#{page}"
       end
-      response = HTTParty.get(url, options)
+      response = HTTParty.get(url)
       return response.body
     rescue => e
       puts e

--- a/lib/tasks/sync_users.rake
+++ b/lib/tasks/sync_users.rake
@@ -1,10 +1,12 @@
 namespace :sync_users do
   desc "Get users from Slack and sync to database"
   task get_users: :environment do
+    # call TeamMembers.syncUsers(null)
   end
 
   desc "Get user groups from Slack and sync to database"
   task get_user_groups: :environment do
+    # call TeamMembers.syncUserGroups(null)
   end
 
 end

--- a/lib/tasks/sync_users.rake
+++ b/lib/tasks/sync_users.rake
@@ -1,11 +1,11 @@
 namespace :sync_users do
   desc "Get users from Slack and sync to database"
-  task get_users: :environment do
+  task :get_users => :environment do
     TeamMembers.syncUsers(nil)
   end
 
   desc "Get user groups from Slack and sync to database"
-  task get_user_groups: :environment do
+  task :get_user_groups => :environment do
     TeamMembers.syncUserGroups
   end
 

--- a/lib/tasks/sync_users.rake
+++ b/lib/tasks/sync_users.rake
@@ -1,12 +1,12 @@
 namespace :sync_users do
   desc "Get users from Slack and sync to database"
   task get_users: :environment do
-    # call TeamMembers.syncUsers(null)
+    TeamMembers.syncUsers(nil)
   end
 
   desc "Get user groups from Slack and sync to database"
   task get_user_groups: :environment do
-    # call TeamMembers.syncUserGroups(null)
+    TeamMembers.syncUserGroups
   end
 
 end

--- a/lib/tasks/sync_users.rake
+++ b/lib/tasks/sync_users.rake
@@ -1,0 +1,10 @@
+namespace :sync_users do
+  desc "Get users from Slack and sync to database"
+  task get_users: :environment do
+  end
+
+  desc "Get user groups from Slack and sync to database"
+  task get_user_groups: :environment do
+  end
+
+end

--- a/lib/team_members.rb
+++ b/lib/team_members.rb
@@ -1,0 +1,31 @@
+require 'slack_connect'
+
+class TeamMembers
+  limit = 100
+
+  def self.syncUsers(page)
+    data = SlackConnect.get('users.list', limit, page)
+    # loop through data.members
+    # id => slack_id
+    # name => display_name
+    # profile.real_name_normalized => actual_name
+    # is_group = false
+    # save users
+    # data.response_metadata.next_cursor => page
+    # if next_cursor is empty string, stop loop
+    # if not empty, call syncUsers(next_cursor)
+  end
+
+  def self.syncUserGroups(page)
+    data = SlackConnect.get('usergroups.list', limit, page)
+    # loop through data.usergroups
+    # id => slack_id
+    # name => display_name
+    # actual_name is null
+    # is_group is true
+    # save as user
+    # data.response_metadata.next_cursor => page
+    # if next_cursor is empty string, stop
+    # if not empty, call syncUserGroups(next_cursor)
+  end
+end

--- a/lib/team_members.rb
+++ b/lib/team_members.rb
@@ -24,8 +24,6 @@ class TeamMembers
     # actual_name is null
     # is_group is true
     # save as user
-    # data.response_metadata.next_cursor => page
-    # if next_cursor is empty string, stop
-    # if not empty, call syncUserGroups(next_cursor)
+    # user groups api does not have pagination (at this time)
   end
 end

--- a/lib/team_members.rb
+++ b/lib/team_members.rb
@@ -5,12 +5,14 @@ class TeamMembers
 
   def self.syncUsers(page)
     @data = SlackConnect.get('users.list', limit, page)
+
     @data.members.map { |item|
       user = User.where(slack_id: item.id).first_or_initialize
       user.assign_attributes({ display_name: item.name, actual_name: item.profile.real_name_normalized, is_group: false })
       return user
     }
     @data.members.save
+
     unless @data.response_metadata.next_cursor.empty?
       # if next_cursor (page) exists
       this.syncUsers(@data.response_metadata.next_cursor)
@@ -19,12 +21,14 @@ class TeamMembers
 
   def self.syncUserGroups(page)
     @data = SlackConnect.get('usergroups.list', limit, page)
-    # loop through data.usergroups
-    # id => slack_id
-    # name => display_name
-    # actual_name is null
-    # is_group is true
-    # save as user
+
+    @data.usergroups.map { |item|
+      user = User.where(slack_id: item.id).first_or_initialize
+      user.assign_attributes({ display_name: item.name, actual_name: null, is_group: true })
+      return user
+    }
+
+    @data.usergroups.save
     # user groups api does not have pagination (at this time)
   end
 end

--- a/lib/team_members.rb
+++ b/lib/team_members.rb
@@ -23,11 +23,9 @@ class TeamMembers
 
     @data[:usergroups].map { |item|
       user = User.where(slack_id: item[:id]).first_or_initialize
-      user.assign_attributes({ display_name: item[:name], is_group: true })
-      return user
+      user.assign_attributes({ display_name: item[:handle], actual_name: item[:name], is_group: true })
+      user.save
     }
-
-    @data[:usergroups].save
     # user groups api does not have pagination (at this time)
   end
 end

--- a/lib/team_members.rb
+++ b/lib/team_members.rb
@@ -13,7 +13,7 @@ class TeamMembers
     }
     @data.members.save
 
-    unless @data.response_metadata.next_cursor.empty?
+    if @data.response_metadata.next_cursor.present?
       # if next_cursor (page) exists
       this.syncUsers(@data.response_metadata.next_cursor)
     end
@@ -24,7 +24,7 @@ class TeamMembers
 
     @data.usergroups.map { |item|
       user = User.where(slack_id: item.id).first_or_initialize
-      user.assign_attributes({ display_name: item.name, actual_name: null, is_group: true })
+      user.assign_attributes({ display_name: item.name, is_group: true })
       return user
     }
 

--- a/lib/team_members.rb
+++ b/lib/team_members.rb
@@ -1,34 +1,33 @@
 require 'slack_connect'
 
 class TeamMembers
-  limit = 100
+  @@limit = 100
 
   def self.syncUsers(page)
-    @data = SlackConnect.get('users.list', limit, page)
+    @data = SlackConnect.get('users.list', @@limit, page)
 
-    @data.members.map { |item|
-      user = User.where(slack_id: item.id).first_or_initialize
-      user.assign_attributes({ display_name: item.name, actual_name: item.profile.real_name_normalized, is_group: false })
-      return user
+    @data[:members].map { |item|
+      user = User.where(slack_id: item[:id]).first_or_initialize
+      user.assign_attributes({ display_name: item[:name], actual_name: item[:profile][:real_name_normalized], is_group: false })
+      user.save
     }
-    @data.members.save
 
-    if @data.response_metadata.next_cursor.present?
+    if @data[:response_metadata][:next_cursor].present?
       # if next_cursor (page) exists
-      this.syncUsers(@data.response_metadata.next_cursor)
+      self.syncUsers(@data[:response_metadata][:next_cursor])
     end
   end
 
-  def self.syncUserGroups(page)
-    @data = SlackConnect.get('usergroups.list', limit, page)
+  def self.syncUserGroups
+    @data = SlackConnect.get('usergroups.list', @@limit, nil)
 
-    @data.usergroups.map { |item|
-      user = User.where(slack_id: item.id).first_or_initialize
-      user.assign_attributes({ display_name: item.name, is_group: true })
+    @data[:usergroups].map { |item|
+      user = User.where(slack_id: item[:id]).first_or_initialize
+      user.assign_attributes({ display_name: item[:name], is_group: true })
       return user
     }
 
-    @data.usergroups.save
+    @data[:usergroups].save
     # user groups api does not have pagination (at this time)
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    slack_id { "W012A3CDE" }
+    display_name { "spengler" }
+    actual_name { "Egon Spengler" }
+    is_group { false }
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,5 +4,12 @@ FactoryBot.define do
     display_name { "spengler" }
     actual_name { "Egon Spengler" }
     is_group { false }
+
+    trait :is_group do
+      slack_id { "S0614TZR7" }
+      display_name { "Team Admins" }
+      actual_name { nil }
+      is_group { true }
+    end
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
 
     trait :is_group do
       slack_id { "S0614TZR7" }
-      display_name { "Team Admins" }
-      actual_name { nil }
+      display_name { "admins" }
+      actual_name { "Team Admins" }
       is_group { true }
     end
   end

--- a/spec/lib/slack_connect_spec.rb
+++ b/spec/lib/slack_connect_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe SlackConnect do
+
+  context '.get' do
+    let(:slack_method) { 'users.list' }
+    let(:limit) { 100 }
+    let(:page) { '' }
+    let(:slack_response) { instance_double(HTTParty::Response, body: slack_response_body) }
+    let(:slack_response_body) { 'response_body' }
+
+    it 'calls users.list with no limit or next page request' do
+      cached_slack_token = ENV["slack_bot_auth"]
+      ENV["slack_bot_auth"] = "12345"
+      limit = nil
+      allow(HTTParty).to receive(:get).
+        with('https://slack.com/api/methods/users.list?token=12345').
+        and_return(slack_response)
+      subject.class.get(slack_method, limit, page)
+      ENV["slack_bot_auth"] = cached_slack_token
+    end
+
+
+    it 'calls users.list with limit' do
+      cached_slack_token = ENV["slack_bot_auth"]
+      ENV["slack_bot_auth"] = "12345"
+      allow(HTTParty).to receive(:get).
+        with('https://slack.com/api/methods/users.list?token=12345&limit=100').
+        and_return(slack_response)
+      subject.class.get(slack_method, limit, page)
+      ENV["slack_bot_auth"] = cached_slack_token
+    end
+
+    it 'calls users.list with limit and next page request' do
+      cached_slack_token = ENV["slack_bot_auth"]
+      ENV["slack_bot_auth"] = "12345"
+      page = 'cde45'
+      allow(HTTParty).to receive(:get).
+        with('https://slack.com/api/methods/users.list?token=12345&limit=100&cursor=cde45').
+        and_return(slack_response)
+      subject.class.get(slack_method, limit, page)
+      ENV["slack_bot_auth"] = cached_slack_token
+    end
+
+
+    it 'calls usergroups.list with Slack API' do
+      cached_slack_token = ENV["slack_bot_auth"]
+      ENV["slack_bot_auth"] = "12345"
+      slack_method = 'usergroups.list'
+      allow(HTTParty).to receive(:get).
+        with('https://slack.com/api/methods/usergroups.list?token=12345&limit=100').
+        and_return(slack_response)
+      subject.class.get(slack_method, limit, page)
+      ENV["slack_bot_auth"] = cached_slack_token
+    end
+  end
+end

--- a/spec/lib/team_members_spec.rb
+++ b/spec/lib/team_members_spec.rb
@@ -1,0 +1,155 @@
+RSpec.describe TeamMembers do
+
+  context '.syncUsers' do
+    let(:first_response) { instance_double(HTTParty::Response, body: first_response_body) }
+    let(:second_response) { instance_double(HTTParty::Response, body: second_response_body) }
+    let(:first_response_body) {
+      {
+      "ok": true,
+      "members": [
+        {
+            "id": "W012A3CDE",
+            "team_id": "T012AB3C4",
+            "name": "spengler",
+            "deleted": false,
+            "real_name": "spengler",
+            "profile": {
+                "avatar_hash": "ge3b51ca72de",
+                "status_text": "Print is dead",
+                "status_emoji": ":books:",
+                "real_name": "Egon Spengler",
+                "display_name": "spengler",
+                "real_name_normalized": "Egon Spengler",
+                "display_name_normalized": "spengler",
+                "email": "spengler@ghostbusters.example.com",
+                "team": "T012AB3C4"
+            },
+            "is_admin": true,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "updated": 1502138686,
+            "is_app_user": false,
+            "has_2fa": false
+        },
+        {
+            "id": "W07QCRPA4",
+            "team_id": "T0G9PQBBK",
+            "name": "glinda",
+            "profile": {
+                "avatar_hash": "8fbdd10b41c6",
+                "first_name": "Glinda",
+                "last_name": "Southgood",
+                "title": "Glinda the Good",
+                "real_name": "Glinda Southgood",
+                "real_name_normalized": "Glinda Southgood",
+                "display_name": "Glinda the Fairly Good",
+                "display_name_normalized": "Glinda the Fairly Good",
+                "email": "glenda@south.oz.coven"
+            },
+            "is_admin": true,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "updated": 1480527098,
+            "has_2fa": false
+        }
+    ],
+    "cache_ts": 1498777272,
+    "response_metadata": {
+      "next_cursor": "dXNlcjpVMEc5V0ZYTlo="
+    }
+    } }
+    let(:second_response_body) {
+      {
+      "ok": true,
+      "members": [
+        {
+            "id": "AA27A3CDE",
+            "team_id": "T012AB3C4",
+            "name": "ajcrowley",
+            "deleted": false,
+            "real_name": "Anthony Crowley",
+            "profile": {
+                "real_name": "Anthony Crowley",
+                "display_name": "ajcrowley",
+                "real_name_normalized": "Anthony Crowley",
+                "display_name_normalized": "ajcrowley",
+                "team": "T012AB3C4"
+            },
+            "is_admin": true,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "updated": 1502138686,
+            "is_app_user": false,
+            "has_2fa": false
+        },
+        {
+            "id": "889QCRPA4",
+            "team_id": "T0G9PQBBK",
+            "name": "angel",
+            "profile": {
+                "first_name": "Aziraphale",
+                "last_name": "Heaven",
+                "real_name": "Aziraphale Heaven",
+                "real_name_normalized": "Aziraphale Heaven",
+            },
+            "is_admin": true,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "updated": 1480527098,
+            "has_2fa": false
+        }
+    ],
+    "cache_ts": 1498777272,
+    "response_metadata": {
+      "next_cursor": ""
+    }
+    } }
+
+    before do
+      allow(HTTParty).to receive(:get).
+        and_return(first_response, second_response)
+    end
+
+    it 'retrieves and creates list of users' do
+      first_response_body[:response_metadata][:next_cursor] = ""
+      subject.class.syncUsers(nil)
+      expect(User.all.count).to eq(2)
+      expect(TeamMembers).not_to receive(:syncUsers)
+    end
+
+    it 'retrieves and updates existing users' do
+      first_response_body[:response_metadata][:next_cursor] = ""
+      FactoryBot.create(:user)
+      subject.class.syncUsers(nil)
+      expect(User.all.count).to eq(2)
+      expect(TeamMembers).not_to receive(:syncUsers)
+    end
+
+    it 'requests next page if present' do
+      subject.class.syncUsers(nil)
+      expect(User.all.count).to eq(4)
+    end
+  end
+
+  context '.syncUserGroups' do
+    it 'retrieves and creates user groups as users' do
+      # calls .get with correct values
+      # creates users
+    end
+
+    it 'retrieves and updates existing user groups' do
+    end
+  end
+end

--- a/spec/lib/team_members_spec.rb
+++ b/spec/lib/team_members_spec.rb
@@ -145,13 +145,92 @@ RSpec.describe TeamMembers do
     end
   end
 
+  ##########################################################
+
   context '.syncUserGroups' do
+    let(:group_response) { instance_double(HTTParty::Response, body: group_response_body) }
+    let(:group_response_body) {
+      {
+        "ok": true,
+        "usergroups": [
+            {
+                "id": "S0614TZR7",
+                "team_id": "T060RNRCH",
+                "is_usergroup": true,
+                "name": "Team Admins",
+                "description": "A group of all Administrators on your team.",
+                "handle": "admins",
+                "is_external": false,
+                "date_create": 1446598059,
+                "date_update": 1446670362,
+                "date_delete": 0,
+                "auto_type": "admin",
+                "created_by": "USLACKBOT",
+                "updated_by": "U060RNRCZ",
+                "prefs": {
+                    "channels": [],
+                    "groups": []
+                },
+                "user_count": "2"
+            },
+            {
+                "id": "S06158AV7",
+                "team_id": "T060RNRCH",
+                "is_usergroup": true,
+                "name": "Team Owners",
+                "description": "A group of all Owners on your team.",
+                "handle": "owners",
+                "is_external": false,
+                "date_create": 1446678371,
+                "date_update": 1446678371,
+                "date_delete": 0,
+                "auto_type": "owner",
+                "created_by": "USLACKBOT",
+                "updated_by": "USLACKBOT",
+                "prefs": {
+                    "channels": [],
+                    "groups": []
+                },
+                "user_count": "1"
+            },
+            {
+                "id": "S0615G0KT",
+                "team_id": "T060RNRCH",
+                "is_usergroup": true,
+                "name": "Marketing Team",
+                "description": "Marketing gurus, PR experts and product advocates.",
+                "handle": "marketing-team",
+                "is_external": false,
+                "date_create": 1446746793,
+                "date_update": 1446747767,
+                "date_delete": 1446748865,
+                "created_by": "U060RNRCZ",
+                "updated_by": "U060RNRCZ",
+                "prefs": {
+                    "channels": [],
+                    "groups": []
+                },
+                "user_count": "0"
+            }
+        ]
+    } }
+
+    before do
+      allow(HTTParty).to receive(:get).
+        and_return(group_response)
+    end
+
     it 'retrieves and creates user groups as users' do
-      # calls .get with correct values
-      # creates users
+      subject.class.syncUserGroups
+      expect(User.all.count).to eq(3)
     end
 
     it 'retrieves and updates existing user groups' do
+      group_response_body[:usergroups][0][:handle] = "theboss"
+      FactoryBot.create(:user, :is_group)
+      subject.class.syncUserGroups
+      expect(User.all.count).to eq(3)
+      expect(User.all.first[:display_name]).to eq("theboss")
     end
   end
 end

--- a/spec/lib/team_members_spec.rb
+++ b/spec/lib/team_members_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe TeamMembers do
             "id": "W07QCRPA4",
             "team_id": "T0G9PQBBK",
             "name": "glinda",
+            "deleted": false,
             "profile": {
                 "avatar_hash": "8fbdd10b41c6",
                 "first_name": "Glinda",
@@ -95,6 +96,7 @@ RSpec.describe TeamMembers do
             "id": "889QCRPA4",
             "team_id": "T0G9PQBBK",
             "name": "angel",
+            "deleted": false,
             "profile": {
                 "first_name": "Aziraphale",
                 "last_name": "Heaven",

--- a/spec/lib/team_members_spec.rb
+++ b/spec/lib/team_members_spec.rb
@@ -131,9 +131,11 @@ RSpec.describe TeamMembers do
 
     it 'retrieves and updates existing users' do
       first_response_body[:response_metadata][:next_cursor] = ""
+      first_response_body[:members][0][:name] = "jeff"
       FactoryBot.create(:user)
       subject.class.syncUsers(nil)
       expect(User.all.count).to eq(2)
+      expect(User.all.first[:display_name]).to eq("jeff")
       expect(TeamMembers).not_to receive(:syncUsers)
     end
 


### PR DESCRIPTION
This is the first PR towards completing issue #6 

Eventually we will want to delete users and user groups that have been dropped, but we'll address that later.

---

- [x] Add new table to database: `users`
  - `slack_id`: string (index, unique)
  - `display_name`: string
  - `actual_name`: string
  - `is_group`: boolean
- [x] Create a task to pull user groups and users from Slack and save them in the database.
- [x] Do not create group or user if already exists.
- [x] Run through pagination of lists from Slack.
- [x] Task is run once a week. (set in Heroku Scheduler)
- [x] Validation tests
- [x] Update README